### PR TITLE
PPPoS changes, pbuf flow control management

### DIFF
--- a/src/core/memp.c
+++ b/src/core/memp.c
@@ -444,4 +444,7 @@ memp_free(memp_t type, void *mem)
     LWIP_HOOK_MEMP_AVAILABLE(type);
   }
 #endif
+#ifdef LWIP_HOOK_MEMP_FREE
+  LWIP_HOOK_MEMP_FREE(type, memp_pools[type]->stats->avail - memp_pools[type]->stats->used, memp_pools[type]->stats->avail);
+#endif // LWIP_HOOK_MEMP_FREE
 }

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -3049,6 +3049,17 @@
 #endif
 
 /**
+ * LWIP_HOOK_MEMP_FREE(memp_t_type):
+ * Called from memp_free() when memp_free is called
+ * Signature:\code{.c}
+ *   void my_hook(memp_t type, unsigned avail, unsigned size);
+ * \endcode
+ */
+#ifdef __DOXYGEN__
+#define LWIP_HOOK_MEMP_FREE(memp_t_type, avail, size)
+#endif
+
+/**
  * LWIP_HOOK_UNKNOWN_ETH_PROTOCOL(pbuf, netif):
  * Called from ethernet_input() when an unknown eth type is encountered.
  * Signature:\code{.c}

--- a/src/include/netif/ppp/ppp_opts.h
+++ b/src/include/netif/ppp/ppp_opts.h
@@ -66,6 +66,13 @@
 #endif
 
 /**
+ * PPPOS_PBUF_RAM_TX_BUFFER==1: Use PBUF_RAM TX buffer
+ */
+#ifndef PPPOS_PBUF_RAM_TX_BUFFER
+#define PPPOS_PBUF_RAM_TX_BUFFER        0
+#endif // PPPOS_PBUF_RAM_TX_BUFFER
+
+/**
  * LWIP_PPP_API==1: Enable PPP API (in pppapi.c)
  */
 #ifndef LWIP_PPP_API

--- a/src/include/netif/ppp/pppos.h
+++ b/src/include/netif/ppp/pppos.h
@@ -95,6 +95,9 @@ struct pppos_pcb_s {
   u16_t in_fcs;                    /* Input Frame Check Sequence value. */
   u8_t in_state;                   /* The input process state. */
   u8_t in_escaped;                 /* Escape next character. */
+#if PPPOS_PBUF_RAM_TX_BUFFER
+  struct pbuf* tx_pbuf;
+#endif // PPPOS_PBUF_RAM_TX_BUFFER
 };
 
 /* Create a new PPPoS session. */

--- a/src/netif/ppp/pppos.c
+++ b/src/netif/ppp/pppos.c
@@ -210,7 +210,14 @@ pppos_write(ppp_pcb *ppp, void *ctx, struct pbuf *p)
   /* Grab an output buffer. Using PBUF_POOL here for tx is ok since the pbuf
      gets freed by 'pppos_output_last' before this function returns and thus
      cannot starve rx. */
+#if !PPPOS_PBUF_RAM_TX_BUFFER
   nb = pbuf_alloc(PBUF_RAW, 0, PBUF_POOL);
+#else
+  if (!pppos->tx_pbuf) {
+    pppos->tx_pbuf = pbuf_alloc(PBUF_RAW, PBUF_POOL_BUFSIZE, PBUF_RAM);
+  }
+  nb = pppos->tx_pbuf;
+#endif // !PPPOS_PBUF_RAM_TX_BUFFER
   if (nb == NULL) {
     PPPDEBUG(LOG_WARNING, ("pppos_write[%d]: alloc fail\n", ppp->netif->num));
     LINK_STATS_INC(link.memerr);
@@ -222,6 +229,10 @@ pppos_write(ppp_pcb *ppp, void *ctx, struct pbuf *p)
 
   /* Set nb->tot_len to actual payload length */
   nb->tot_len = p->len;
+
+#if PPPOS_PBUF_RAM_TX_BUFFER
+  nb->len = 0;
+#endif // PPPOS_PBUF_RAM_TX_BUFFER
 
   /* If the link has been idle, we'll send a fresh flag character to
    * flush any noise. */
@@ -261,7 +272,14 @@ pppos_netif_output(ppp_pcb *ppp, void *ctx, struct pbuf *pb, u16_t protocol)
   /* Grab an output buffer. Using PBUF_POOL here for tx is ok since the pbuf
      gets freed by 'pppos_output_last' before this function returns and thus
      cannot starve rx. */
+#if !PPPOS_PBUF_RAM_TX_BUFFER
   nb = pbuf_alloc(PBUF_RAW, 0, PBUF_POOL);
+#else
+  if (!pppos->tx_pbuf) {
+    pppos->tx_pbuf = pbuf_alloc(PBUF_RAW, PBUF_POOL_BUFSIZE, PBUF_RAM);
+  }
+  nb = pppos->tx_pbuf;
+#endif // !PPPOS_PBUF_RAM_TX_BUFFER
   if (nb == NULL) {
     PPPDEBUG(LOG_WARNING, ("pppos_netif_output[%d]: alloc fail\n", ppp->netif->num));
     LINK_STATS_INC(link.memerr);
@@ -272,6 +290,10 @@ pppos_netif_output(ppp_pcb *ppp, void *ctx, struct pbuf *pb, u16_t protocol)
 
   /* Set nb->tot_len to actual payload length */
   nb->tot_len = pb->tot_len;
+
+#if PPPOS_PBUF_RAM_TX_BUFFER
+  nb->len = 0;
+#endif // PPPOS_PBUF_RAM_TX_BUFFER
 
   /* If the link has been idle, we'll send a fresh flag character to
    * flush any noise. */
@@ -405,6 +427,12 @@ pppos_destroy(ppp_pcb *ppp, void *ctx)
   /* input pbuf left ? */
   pppos_input_free_current_packet(pppos);
 #endif /* PPP_INPROC_IRQ_SAFE */
+
+#if PPPOS_PBUF_RAM_TX_BUFFER
+  if (pppos->tx_pbuf) {
+    pbuf_free(pppos->tx_pbuf);
+  }
+#endif // PPPOS_PBUF_RAM_TX_BUFFER
 
   LWIP_MEMPOOL_FREE(PPPOS_PCB, pppos);
   return ERR_OK;
@@ -880,7 +908,9 @@ pppos_output_last(pppos_pcb *pppos, err_t err, struct pbuf *nb, u16_t *fcs)
   MIB2_STATS_NETIF_ADD(ppp->netif, ifoutoctets, nb->tot_len);
   MIB2_STATS_NETIF_INC(ppp->netif, ifoutucastpkts);
   LINK_STATS_INC(link.xmit);
+#if !PPPOS_PBUF_RAM_TX_BUFFER
   pbuf_free(nb);
+#endif // !PPPOS_PBUF_RAM_TX_BUFFER
   return ERR_OK;
 
 failed:
@@ -888,7 +918,9 @@ failed:
   LINK_STATS_INC(link.err);
   LINK_STATS_INC(link.drop);
   MIB2_STATS_NETIF_INC(ppp->netif, ifoutdiscards);
+#if !PPPOS_PBUF_RAM_TX_BUFFER
   pbuf_free(nb);
+#endif // !PPPOS_PBUF_RAM_TX_BUFFER
   return err;
 }
 

--- a/src/netif/ppp/pppos.c
+++ b/src/netif/ppp/pppos.c
@@ -705,7 +705,8 @@ pppos_input(ppp_pcb *ppp, u8_t *s, int l)
               /* No free buffers.  Drop the input packet and let the
                * higher layers deal with it.  Continue processing
                * the received pbuf chain in case a new packet starts. */
-              PPPDEBUG(LOG_ERR, ("pppos_input[%d]: NO FREE PBUFS!\n", ppp->netif->num));
+              /* Particle: This is a really annoying log message, ignore it */
+              // PPPDEBUG(LOG_ERR, ("pppos_input[%d]: NO FREE PBUFS!\n", ppp->netif->num));
               LINK_STATS_INC(link.memerr);
               pppos_input_drop(pppos);
               pppos->in_state = PDSTART;  /* Wait for flag sequence. */


### PR DESCRIPTION
### Description

1. Adds `LWIP_HOOK_MEMP_FREE` to get notified when pool entries are being freed
2. Adds `PPPOS_PBUF_RAM_TX_BUFFER` option to use single `PBUF_RAM` TX buffer instead of `PBUF_POOL`, as with heavy RX traffic it's easy to not be able to send anything if the `PBUF_POOL` is empty
3. Disables annoying per-byte `NO FREE PBUFS!` log message. We have ways to detect that in DeviceOS as well