### PR TITLE
sockets: SIOCSPGRP implementation and sys_arch_thread_notify()

### DIFF
--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -2078,6 +2078,10 @@
 #if !defined LWIP_SOCKET_POLL || defined __DOXYGEN__
 #define LWIP_SOCKET_POLL                1
 #endif
+
+#if !defined LWIP_SOCKET_NOTIFY_THREAD || defined __DOXYGEN__
+#define LWIP_SOCKET_NOTIFY_THREAD       0
+#endif
 /**
  * @}
  */

--- a/src/include/lwip/priv/sockets_priv.h
+++ b/src/include/lwip/priv/sockets_priv.h
@@ -89,6 +89,9 @@ struct lwip_sock {
 #define LWIP_SOCK_FD_FREE_TCP  1
 #define LWIP_SOCK_FD_FREE_FREE 2
 #endif
+#if LWIP_SOCKET_NOTIFY_THREAD
+  void* notify;
+#endif /* LWIP_SOCKET_NOTIFY_THREAD */
 };
 
 #ifndef set_errno

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -430,6 +430,10 @@ typedef struct ipv6_mreq {
 #define SIOCATMARK  _IOR('s',  7, unsigned long)  /* at oob mark? */
 #endif
 
+#ifndef SIOCSPGRP
+#define SIOCSPGRP	_IOW('s', 8, void*)
+#endif // SIOCSPGRP
+
 /* commands for fnctl */
 #ifndef F_GETFL
 #define F_GETFL 3

--- a/src/include/lwip/sys.h
+++ b/src/include/lwip/sys.h
@@ -419,6 +419,8 @@ void sys_mbox_set_invalid(sys_mbox_t *mbox);
  * @param prio priority of the new thread (may be ignored by ports) */
 sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg, int stacksize, int prio);
 
+void sys_arch_thread_notify(void* thread);
+
 #endif /* NO_SYS */
 
 /**


### PR DESCRIPTION
### Description

Adds support for `SIOCSPGRP` ioctl. Uses threads instead of normal `pid_t` (should we change that and still use `pid_t` and cast from/to abstract thread handles)?

### References

- https://github.com/particle-iot/device-os/pull/2113