### PR TITLE
[ppp] fsm: ignore Configure-Request in opened state option

### DIFF
--- a/src/include/netif/ppp/ppp.h
+++ b/src/include/netif/ppp/ppp.h
@@ -288,12 +288,13 @@ typedef struct ppp_settings_s {
   u8_t  fsm_max_conf_req_transmits;  /* Maximum Configure-Request transmissions */
   u8_t  fsm_max_term_transmits;      /* Maximum Terminate-Request transmissions */
   u8_t  fsm_max_nak_loops;           /* Maximum number of nak loops tolerated */
+  u8_t  fsm_ignore_conf_req_opened;  /* Ignore Configure-Request in opened state if
+                                        not disagreeing with the options */
 
   u8_t  lcp_loopbackfail;     /* Number of times we receive our magic number from the peer
                                  before deciding the link is looped-back. */
   u8_t  lcp_echo_interval;    /* Interval between LCP echo-requests */
   u8_t  lcp_echo_fails;       /* Tolerance to unanswered echo-requests */
-
 } ppp_settings;
 
 #if PPP_SERVER

--- a/src/include/netif/ppp/ppp_opts.h
+++ b/src/include/netif/ppp/ppp_opts.h
@@ -412,6 +412,14 @@
 #endif
 
 /**
+ * FSM_DEFIGNORECONFREQOPENED: Ignore Configure-Requests in opened state
+ * if not disagreeing. Default off.
+ */
+#ifndef FSM_DEFIGNORECONFREQOPENED
+#define FSM_DEFIGNORECONFREQOPENED      0
+#endif
+
+/**
  * UPAP_DEFTIMEOUT: Timeout (seconds) for retransmitting req
  */
 #ifndef UPAP_DEFTIMEOUT

--- a/src/netif/ppp/fsm.c
+++ b/src/netif/ppp/fsm.c
@@ -401,8 +401,9 @@ static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
     ppp_pcb *pcb = f->pcb;
 	/* Ignore only if the option is enabled and we've passed the
 	 * authentication stage and it's not LCP that attempts to get renegotiated */
-	int ignore_conf_req_opened = pcb->settings.fsm_ignore_conf_req_opened &&
-			pcb->auth_done && f->protocol != PPP_LCP;
+	int ignore_conf_req_opened = (f->state == PPP_FSM_OPENED) &&
+			pcb->settings.fsm_ignore_conf_req_opened &&
+			pcb->auth_done && (f->protocol != PPP_LCP);
 
     switch( f->state ){
     case PPP_FSM_CLOSED:

--- a/src/netif/ppp/fsm.c
+++ b/src/netif/ppp/fsm.c
@@ -385,12 +385,24 @@ void fsm_input(fsm *f, u_char *inpacket, int l) {
     }
 }
 
+static void fsm_rconfreq_down_restart(fsm *f) {
+	if( f->callbacks->down )
+		(*f->callbacks->down)(f);	/* Inform upper layers */
+
+	fsm_sconfreq(f, 0);		/* Send initial Configure-Request */
+	f->state = PPP_FSM_REQSENT;
+}
 
 /*
  * fsm_rconfreq - Receive Configure-Request.
  */
 static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
     int code, reject_if_disagree;
+    ppp_pcb *pcb = f->pcb;
+	/* Ignore only if the option is enabled and we've passed the
+	 * authentication stage and it's not LCP that attempts to get renegotiated */
+	int ignore_conf_req_opened = pcb->settings.fsm_ignore_conf_req_opened &&
+			pcb->auth_done && f->protocol != PPP_LCP;
 
     switch( f->state ){
     case PPP_FSM_CLOSED:
@@ -402,11 +414,10 @@ static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
 	return;
 
     case PPP_FSM_OPENED:
-	/* Go down and restart negotiation */
-	if( f->callbacks->down )
-	    (*f->callbacks->down)(f);	/* Inform upper layers */
-	fsm_sconfreq(f, 0);		/* Send initial Configure-Request */
-	f->state = PPP_FSM_REQSENT;
+	if (!ignore_conf_req_opened) {
+		/* Go down and restart negotiation */
+		fsm_rconfreq_down_restart(f);
+	}
 	break;
 
     case PPP_FSM_STOPPED:
@@ -425,10 +436,18 @@ static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
     if (f->callbacks->reqci){		/* Check CI */
 	reject_if_disagree = (f->nakloops >= f->maxnakloops);
 	code = (*f->callbacks->reqci)(f, inp, &len, reject_if_disagree);
-    } else if (len)
-	code = CONFREJ;			/* Reject all CI */
-    else
-	code = CONFACK;
+	} else if (len) {
+		code = CONFREJ;			/* Reject all CI */
+	} else {
+		code = CONFACK;
+	}
+
+	if (ignore_conf_req_opened && code != CONFACK) {
+		/* Go down and restart negotiation */
+		fsm_rconfreq_down_restart(f);
+	} else {
+		FSMDEBUG(("%s: Non-conflicting Configure-Request in opened state, ACKing", PROTO_NAME(f)));
+	}
 
     /* send the Ack, Nak or Rej to the peer */
     fsm_sdata(f, code, id, inp, len);

--- a/src/netif/ppp/fsm.c
+++ b/src/netif/ppp/fsm.c
@@ -402,8 +402,7 @@ static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
 	/* Ignore only if the option is enabled and we've passed the
 	 * authentication stage and it's not LCP that attempts to get renegotiated */
 	int ignore_conf_req_opened = (f->state == PPP_FSM_OPENED) &&
-			pcb->settings.fsm_ignore_conf_req_opened &&
-			pcb->auth_done && (f->protocol != PPP_LCP);
+			pcb->settings.fsm_ignore_conf_req_opened;
 
     switch( f->state ){
     case PPP_FSM_CLOSED:
@@ -459,8 +458,14 @@ static void fsm_rconfreq(fsm *f, u_char id, u_char *inp, int len) {
 	    f->state = PPP_FSM_OPENED;
 	    if (f->callbacks->up)
 		(*f->callbacks->up)(f);	/* Inform upper layers */
-	} else
-	    f->state = PPP_FSM_ACKSENT;
+	} else {
+		if (!ignore_conf_req_opened) {
+			f->state = PPP_FSM_ACKSENT;
+		} else {
+			/* Stay in opened state */
+			f->state = PPP_FSM_OPENED;
+		}
+	}
 	f->nakloops = 0;
 
     } else {

--- a/src/netif/ppp/ppp.c
+++ b/src/netif/ppp/ppp.c
@@ -695,6 +695,7 @@ ppp_pcb *ppp_new(struct netif *pppif, const struct link_callbacks *callbacks, vo
   pcb->settings.fsm_max_conf_req_transmits = FSM_DEFMAXCONFREQS;
   pcb->settings.fsm_max_term_transmits = FSM_DEFMAXTERMREQS;
   pcb->settings.fsm_max_nak_loops = FSM_DEFMAXNAKLOOPS;
+  pcb->settings.fsm_ignore_conf_req_opened = FSM_DEFIGNORECONFREQOPENED;
 
   pcb->netif = pppif;
   MIB2_INIT_NETIF(pppif, snmp_ifType_ppp, 0);


### PR DESCRIPTION
### Description

This PR adds a PPP configuration option to ignore standard behavior for receiving a Configure-Request in an already opened state - that is to bring the protocol down and start renegotiation. Instead this option will allow us to respond with ACK immediately without tearing down the protocol if the protocol handler does not disagree with the set of options passed in the request and we are already authenticated and it's not LCP that is going into renegotiation. Otherwise, we'll follow the standard behavior.

NOTE: we are going off standard with this, but it should be an acceptable behavior and the PPP state machine should be able to handle this properly.

The reason why we are adding this is because SARA R4 modems have a broken PPP implementation and immediately after we IPCP up, it will send us another often empty Configure-Requests without any options which increases the connection times by a lot due to us having to perform the renegotiation.

An example of IPCP behavior:

 <pre><code>
0000092017 [lwip] TRACE: rcvd [IPCP ConfAck id=0x4 <addr 10.218.154.169> <msdns1 174.47.40.106> <msdns2 174.47.20.106>]
0000092018 [system.nm] INFO: State changed: IFACE_UP -> IFACE_LINK_UP
0000092019 [lwip] TRACE: sifup[3]: err_code=0
0000092019 [net.ppp.client] TRACE: PPP thread event UP
0000092020 [system.nm] INFO: State changed: IFACE_LINK_UP -> IP_CONFIGURED
0000092022 [lwip] TRACE: ppp phase changed[3]: phase=10
0000092022 [net.ppp.client] TRACE: PPP phase -> 10
0000093235 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 58
0000093242 [lwip] TRACE: pppos_input[3]: got 10 bytes
<b>0000093243 [lwip] TRACE: rcvd [IPCP ConfReq id=0x5]
0000093243 [system.nm] INFO: State changed: IP_CONFIGURED -> IFACE_UP
0000093244 [lwip] TRACE: sifdown[3]: err_code=0</b>
0000093244 [lwip] TRACE: ppp phase changed[3]: phase=9
0000093245 [net.ppp.client] TRACE: PPP phase -> 9
0000093245 [lwip] TRACE: sent [IPCP ConfReq id=0x5 <addr 0.0.0.0> <msdns1 8.8.8.8> <msdns2 8.8.4.4>]
0000093246 [lwip] TRACE: pppos_write[3]: len=26
0000093247 [lwip] TRACE: sent [IPCP ConfAck id=0x5]
0000093248 [lwip] TRACE: pppos_write[3]: len=8
0000094345 [lwip] TRACE: sent [LCP EchoReq id=0x2 magic=0x585339e5]
0000094345 [lwip] TRACE: pppos_write[3]: len=12
0000094353 [lwip] TRACE: pppos_input[3]: got 10 bytes
0000094354 [lwip] TRACE: rcvd [IPCP ConfReq id=0x6]
0000094354 [lwip] TRACE: sent [IPCP ConfAck id=0x6]
0000094355 [lwip] TRACE: pppos_write[3]: len=8
0000094355 [lwip] TRACE: pppos_input[3]: got 28 bytes
0000094356 [lwip] TRACE: pppos_input[3]: got 25 bytes
0000094357 [lwip] TRACE: rcvd [IPCP ConfNak id=0x5 <addr 10.218.154.169> <msdns1 174.47.40.106> <msdns2 174.47.20.106>]
0000094358 [lwip] TRACE: sent [IPCP ConfReq id=0x6 <addr 10.218.154.169> <msdns1 174.47.40.106> <msdns2 174.47.20.106>]
0000094359 [lwip] TRACE: pppos_write[3]: len=26
0000094360 [lwip] TRACE: rcvd [LCP EchoRep id=0x2 magic=0x3860ec49 58 53 39 e5]
0000094574 [lwip] TRACE: pppos_input[3]: got 10 bytes
0000094575 [lwip] TRACE: pppos_input[3]: got 28 bytes
0000094576 [lwip] TRACE: rcvd [IPCP ConfReq id=0x7]
0000094577 [lwip] TRACE: sent [IPCP ConfAck id=0x7]
0000094577 [lwip] TRACE: pppos_write[3]: len=8
0000094578 [lwip] TRACE: rcvd [IPCP ConfAck id=0x6 <addr 10.218.154.169> <msdns1 174.47.40.106> <msdns2 174.47.20.106>]
0000094579 [system.nm] INFO: State changed: IFACE_UP -> IFACE_LINK_UP
0000094580 [lwip] TRACE: sifup[3]: err_code=0
0000094581 [net.ppp.client] TRACE: PPP thread event UP
0000094581 [system.nm] INFO: State changed: IFACE_LINK_UP -> IP_CONFIGURED
</code></pre>

With this option enabled (and we are only enabling it for R4-based devices) the conversation looks like this:

<pre><code>
0000016926 [lwip] TRACE: sent [LCP EchoReq id=0x1 magic=0x585220ef]
0000016927 [lwip] TRACE: pppos_write[3]: len=12
0000016934 [lwip] TRACE: pppos_input[3]: got 10 bytes
0000016935 [lwip] TRACE: rcvd [IPCP ConfReq id=0x5]
0000016936 [lwip] TRACE: sent [IPCP ConfAck id=0x5]
0000016936 [lwip] TRACE: pppos_input[3]: got 28 bytes
0000016937 [lwip] TRACE: pppos_input[3]: got 25 bytes
0000016937 [lwip] TRACE: pppos_write[3]: len=8
0000016938 [lwip] TRACE: rcvd [IPCP ConfAck id=0x2 <addr 10.218.154.169> <msdns1 174.47.40.106> <msdns2 174.47.20.106>]
0000016939 [system.nm] INFO: State changed: IFACE_UP -> IFACE_LINK_UP
<b>0000016940 [lwip] TRACE: sifup[3]: err_code=0</b>
0000016941 [net.ppp.client] TRACE: PPP thread event UP
0000016941 [net.ppp.client] TRACE: State CONNECTING -> CONNECTED
0000016942 [system.nm] INFO: State changed: IFACE_LINK_UP -> IP_CONFIGURED
0000016942 [net.pppncp] TRACE: Negotiated MTU: 1500
0000016944 [lwip] TRACE: ppp phase changed[3]: phase=10
0000016944 [net.ppp.client] TRACE: PPP phase -> 10
0000016944 [system] INFO: Cloud: connecting
0000016947 [system] INFO: Cloud socket connected
0000016947 [comm.protocol.handshake] INFO: Establish secure connection
0000017075 [lwip] TRACE: pppos_input[3]: got 10 bytes
<b>0000017075 [lwip] TRACE: rcvd [IPCP ConfReq id=0x6]
0000017076 [lwip] TRACE: sent [IPCP ConfAck id=0x6]</b>
0000017077 [lwip] TRACE: pppos_write[3]: len=8
</code></pre>

This change cuts down connection times on R4-based devices by 10-20 seconds in some cases and also allows us to get out of the renegotiation loop in LCP (don't have a log currently at hand).

### References

- [CH64715]