### PR TITLE
Fix dual stack UDP bind behavior with LWIP_IPV6_DEFINES_ONLY

### DIFF
--- a/src/api/api_lib.c
+++ b/src/api/api_lib.c
@@ -318,7 +318,7 @@ netconn_bind(struct netconn *conn, const ip_addr_t *addr, u16_t port)
   }
 #endif /* LWIP_IPV4 */
 
-#if LWIP_IPV4 && LWIP_IPV6
+#if LWIP_IPV4 && (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
   /* "Socket API like" dual-stack support: If IP to bind to is IP6_ADDR_ANY,
    * and NETCONN_FLAG_IPV6_V6ONLY is 0, use IP_ANY_TYPE to bind
    */

--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -612,7 +612,7 @@ pcb_new(struct api_msg *msg)
 
   LWIP_ASSERT("pcb_new: pcb already allocated", msg->conn->pcb.tcp == NULL);
 
-#if LWIP_IPV6 && LWIP_IPV4
+#if (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY) && LWIP_IPV4
   /* IPv6: Dual-stack by default, unless netconn_set_ipv6only() is called */
   if (NETCONNTYPE_ISIPV6(netconn_type(msg->conn))) {
     iptype = IPADDR_TYPE_ANY;
@@ -1465,7 +1465,7 @@ lwip_netconn_do_listen(void *m)
 #else  /* TCP_LISTEN_BACKLOG */
           backlog = TCP_DEFAULT_LISTEN_BACKLOG;
 #endif /* TCP_LISTEN_BACKLOG */
-#if LWIP_IPV4 && LWIP_IPV6
+#if LWIP_IPV4 && (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
           /* "Socket API like" dual-stack support: If IP to listen to is IP6_ADDR_ANY,
             * and NETCONN_FLAG_IPV6_V6ONLY is NOT set, use IP_ANY_TYPE to listen
             */

--- a/src/core/raw.c
+++ b/src/core/raw.c
@@ -636,7 +636,7 @@ raw_new_ip_type(u8_t type, u8_t proto)
   struct raw_pcb *pcb;
   LWIP_ASSERT_CORE_LOCKED();
   pcb = raw_new(proto);
-#if LWIP_IPV4 && LWIP_IPV6
+#if LWIP_IPV4 && (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
   if (pcb != NULL) {
     IP_SET_TYPE_VAL(pcb->local_ip,  type);
     IP_SET_TYPE_VAL(pcb->remote_ip, type);

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -1963,7 +1963,7 @@ tcp_new_ip_type(u8_t type)
 {
   struct tcp_pcb *pcb;
   pcb = tcp_alloc(TCP_PRIO_NORMAL);
-#if LWIP_IPV4 && LWIP_IPV6
+#if LWIP_IPV4 && (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
   if (pcb != NULL) {
     IP_SET_TYPE_VAL(pcb->local_ip, type);
     IP_SET_TYPE_VAL(pcb->remote_ip, type);

--- a/src/core/udp.c
+++ b/src/core/udp.c
@@ -1259,7 +1259,7 @@ udp_new_ip_type(u8_t type)
   LWIP_ASSERT_CORE_LOCKED();
 
   pcb = udp_new();
-#if LWIP_IPV4 && LWIP_IPV6
+#if LWIP_IPV4 && (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
   if (pcb != NULL) {
     IP_SET_TYPE_VAL(pcb->local_ip,  type);
     IP_SET_TYPE_VAL(pcb->remote_ip, type);

--- a/src/include/lwip/api.h
+++ b/src/include/lwip/api.h
@@ -80,7 +80,7 @@ extern "C" {
 /** If a nonblocking write has been rejected before, poll_tcp needs to
     check if the netconn is writable again */
 #define NETCONN_FLAG_CHECK_WRITESPACE         0x10
-#if LWIP_IPV6
+#if LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY
 /** If this flag is set then only IPv6 communication is allowed on the
     netconn. As per RFC#3493 this features defaults to OFF allowing
     dual-stack usage by default. */
@@ -114,7 +114,7 @@ enum netconn_type {
   NETCONN_INVALID     = 0,
   /** TCP IPv4 */
   NETCONN_TCP         = 0x10,
-#if LWIP_IPV6
+#if LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY
   /** TCP IPv6 */
   NETCONN_TCP_IPV6    = NETCONN_TCP | NETCONN_TYPE_IPV6 /* 0x18 */,
 #endif /* LWIP_IPV6 */
@@ -125,7 +125,7 @@ enum netconn_type {
   /** UDP IPv4 no checksum */
   NETCONN_UDPNOCHKSUM = 0x22,
 
-#if LWIP_IPV6
+#if LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY
   /** UDP IPv6 (dual-stack by default, unless you call @ref netconn_set_ipv6only) */
   NETCONN_UDP_IPV6         = NETCONN_UDP | NETCONN_TYPE_IPV6 /* 0x28 */,
   /** UDP IPv6 lite (dual-stack by default, unless you call @ref netconn_set_ipv6only) */
@@ -136,7 +136,7 @@ enum netconn_type {
 
   /** Raw connection IPv4 */
   NETCONN_RAW         = 0x40
-#if LWIP_IPV6
+#if LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY
   /** Raw connection IPv6 (dual-stack by default, unless you call @ref netconn_set_ipv6only) */
   , NETCONN_RAW_IPV6    = NETCONN_RAW | NETCONN_TYPE_IPV6 /* 0x48 */
 #endif /* LWIP_IPV6 */
@@ -381,7 +381,7 @@ err_t   netconn_err(struct netconn *conn);
 /** Get the blocking status of netconn calls (@todo: write/send is missing) */
 #define netconn_is_nonblocking(conn)        (((conn)->flags & NETCONN_FLAG_NON_BLOCKING) != 0)
 
-#if LWIP_IPV6
+#if (LWIP_IPV6 || LWIP_IPV6_DEFINES_ONLY)
 /** @ingroup netconn_common
  * TCP: Set the IPv6 ONLY status of netconn calls (see NETCONN_FLAG_IPV6_V6ONLY)
  */


### PR DESCRIPTION
UDP socket when bound to `AF_INET6` `IN6ADDR_ANY` address, should normally work in dual-stack mode. With recent optimizations for Gen 3 platforms introducing `LWIP_IPV6_DEFINES_ONLY`, this got broken.