### PR TITLE
[sockets] implement SO_TIMESTAMP/SO_TIMESTAMPING

### DIFF
--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -266,6 +266,12 @@ recv_udp(void *arg, struct udp_pcb *pcb, struct pbuf *p,
       buf->toport_chksum = udphdr->dest;
     }
 #endif /* LWIP_NETBUF_RECVINFO */
+#if LWIP_NETBUF_TIMESTAMP
+    if (conn->flags & NETCONN_FLAG_TIMESTAMP) {
+      buf->timestamp = sys_now();
+      buf->flags |= NETBUF_FLAG_TIMESTAMP;
+    }
+#endif /* LWIP_NETBUF_TIMESTAMP */
   }
 
   len = p->tot_len;

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -1182,6 +1182,23 @@ lwip_recvfrom_udp_raw(struct lwip_sock *sock, int flags, struct msghdr *msg, u16
       }
     }
 #endif /* LWIP_NETBUF_RECVINFO */
+#if LWIP_NETBUF_TIMESTAMP
+    if (buf->flags & NETBUF_FLAG_TIMESTAMP) {
+      if (msg->msg_controllen >= CMSG_SPACE(sizeof(struct timespec))) {
+        struct cmsghdr *chdr = CMSG_FIRSTHDR(msg); /* This will always return a header!! */
+        struct timespec *ts = (struct timespec *)CMSG_DATA(chdr);
+        chdr->cmsg_level = SOL_SOCKET;
+        chdr->cmsg_type = SO_TIMESTAMPING;
+        chdr->cmsg_len = CMSG_LEN(sizeof(struct timespec));
+        msg->msg_controllen = CMSG_SPACE(sizeof(struct timespec));
+        ts->tv_sec = buf->timestamp / 1000;
+        ts->tv_nsec = (buf->timestamp % 1000) * 1000000;
+        wrote_msg = 1;
+      } else {
+        msg->msg_flags |= MSG_CTRUNC;
+      }
+    }
+#endif /* LWIP_NETBUF_TIMESTAMP */
 
     if (!wrote_msg) {
       msg->msg_controllen = 0;
@@ -3486,6 +3503,16 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
           }
         }
         break;
+#if LWIP_NETBUF_TIMESTAMP
+        case SO_TIMESTAMPING:
+          LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, int, NETCONN_UDP);
+          if (*(const int *)optval) {
+            sock->conn->flags |= NETCONN_FLAG_TIMESTAMP;
+          } else {
+            sock->conn->flags &= ~NETCONN_FLAG_TIMESTAMP;
+          }
+          break;
+#endif /* LWIP_NETBUF_TIMESTAMP */
         default:
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, SOL_SOCKET, UNIMPL: optname=0x%x, ..)\n",
                                       s, optname));

--- a/src/core/dns.c
+++ b/src/core/dns.c
@@ -95,6 +95,10 @@
 #include "lwip/dns.h"
 #include "lwip/prot/dns.h"
 
+#ifdef LWIP_HOOK_FILENAME
+#include LWIP_HOOK_FILENAME
+#endif // LWIP_HOOK_FILENAME
+
 #include <string.h>
 
 /** Random generator function to create random TXIDs and source ports for queries */
@@ -769,6 +773,9 @@ dns_send(u8_t idx)
   const char *hostname, *hostname_part;
   u8_t n;
   u8_t pcb_idx;
+#ifdef LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
+  u8_t unbind = 0;
+#endif // LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
   struct dns_table_entry *entry = &dns_table[idx];
 
   LWIP_DEBUGF(DNS_DEBUG, ("dns_send: dns_servers[%"U16_F"] \"%s\": request\n",
@@ -860,8 +867,22 @@ dns_send(u8_t idx)
     {
       dst_port = DNS_SERVER_PORT;
       dst = &dns_servers[entry->server_idx];
+#ifdef LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
+      struct netif* bind_netif = LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX(entry->server_idx);
+      if (bind_netif) {
+        unbind = 1;
+        // This forces udp_sendto to pick bind_netif as an outgoing interface, bypassing
+        // the routing table/hooks.
+        udp_bind_netif(dns_pcbs[pcb_idx], bind_netif);
+      }
+#endif // LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
     }
     err = udp_sendto(dns_pcbs[pcb_idx], p, dst, dst_port);
+#ifdef LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
+    if (unbind) {
+      udp_bind_netif(dns_pcbs[pcb_idx], NULL);
+    }
+#endif // LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX
 
     /* free pbuf */
     pbuf_free(p);

--- a/src/core/pbuf.c
+++ b/src/core/pbuf.c
@@ -220,6 +220,9 @@ pbuf_init_alloced_pbuf(struct pbuf *p, void *payload, u16_t tot_len, u16_t len, 
  * @return the allocated pbuf. If multiple pbufs where allocated, this
  * is the first pbuf of a pbuf chain.
  */
+
+extern void lwip_log_message(const char *fmt, ...);
+
 struct pbuf *
 pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
 {
@@ -242,6 +245,7 @@ pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
         u16_t qlen;
         q = (struct pbuf *)memp_malloc(MEMP_PBUF_POOL);
         if (q == NULL) {
+          lwip_log_message("pbuf alloc error PBUF_POOL\r\n");
           PBUF_POOL_IS_EMPTY();
           /* free chain so far allocated */
           if (p) {
@@ -283,6 +287,7 @@ pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
       /* If pbuf is to be allocated in RAM, allocate memory for it. */
       p = (struct pbuf *)mem_malloc(alloc_len);
       if (p == NULL) {
+        lwip_log_message("pbuf alloc error PBUF_RAM\r\n");
         return NULL;
       }
       pbuf_init_alloced_pbuf(p, LWIP_MEM_ALIGN((void *)((u8_t *)p + SIZEOF_STRUCT_PBUF + offset)),

--- a/src/include/lwip/api.h
+++ b/src/include/lwip/api.h
@@ -90,6 +90,10 @@ extern "C" {
 /** Received packet info will be recorded for this netconn */
 #define NETCONN_FLAG_PKTINFO                  0x40
 #endif /* LWIP_NETBUF_RECVINFO */
+/** NOTE: reusing the same value as for NETCONN_FLAG_PKTINFO, these options are mutually exclusive */
+#if LWIP_NETBUF_TIMESTAMP
+#define NETCONN_FLAG_TIMESTAMP                0x40
+#endif /* LWIP_NETBUF_TIMESTAMP */
 /** A FIN has been received but not passed to the application yet */
 #define NETCONN_FIN_RX_PENDING                0x80
 

--- a/src/include/lwip/netbuf.h
+++ b/src/include/lwip/netbuf.h
@@ -55,19 +55,24 @@ extern "C" {
 #define NETBUF_FLAG_DESTADDR    0x01
 /** This netbuf includes a checksum */
 #define NETBUF_FLAG_CHKSUM      0x02
+/** This netbuf includes a timestamp */
+#define NETBUF_FLAG_TIMESTAMP   0x80
 
 /** "Network buffer" - contains data and addressing info */
 struct netbuf {
   struct pbuf *p, *ptr;
   ip_addr_t addr;
   u16_t port;
-#if LWIP_NETBUF_RECVINFO || LWIP_CHECKSUM_ON_COPY
+#if LWIP_NETBUF_RECVINFO || LWIP_CHECKSUM_ON_COPY || LWIP_NETBUF_TIMESTAMP
   u8_t flags;
   u16_t toport_chksum;
 #if LWIP_NETBUF_RECVINFO
   ip_addr_t toaddr;
 #endif /* LWIP_NETBUF_RECVINFO */
 #endif /* LWIP_NETBUF_RECVINFO || LWIP_CHECKSUM_ON_COPY */
+#if LWIP_NETBUF_TIMESTAMP
+  u32_t timestamp;
+#endif /* LWIP_NETBUF_TIMESTAMP */
 };
 
 /* Network buffer functions: */

--- a/src/include/lwip/opt.h
+++ b/src/include/lwip/opt.h
@@ -1208,6 +1208,17 @@
 #if !defined LWIP_NETBUF_RECVINFO || defined __DOXYGEN__
 #define LWIP_NETBUF_RECVINFO            0
 #endif
+
+/**
+ * LWIP_NETBUF_TIMESTAMP==1: append timestamp to netbufs
+ */
+#if !defined LWIP_NETBUF_TIMESTAMP || defined __DOXYGEN__
+#define LWIP_NETBUF_TIMESTAMP            0
+#endif
+
+#if LWIP_NETBUF_TIMESTAMP && LWIP_NETBUF_RECVINFO
+#error "LWIP_NETBUF_TIMESTAMP and LWIP_NETBUF_RECVINFO cannot be enabled together"
+#endif /* LWIP_NETBUF_TIMESTAMP && LWIP_NETBUF_RECVINFO */
 /**
  * @}
  */

--- a/src/include/lwip/sockets.h
+++ b/src/include/lwip/sockets.h
@@ -219,6 +219,8 @@ struct ifreq {
 #define SO_CONTIMEO     0x1009 /* Unimplemented: connect timeout */
 #define SO_NO_CHECK     0x100a /* don't create UDP checksum */
 #define SO_BINDTODEVICE 0x100b /* bind to device */
+#define SO_TIMESTAMPING 0x1025 /* generate timestamp for recvd packets */
+#define SO_TIMESTAMP    SO_TIMESTAMPING /* generate timestamp for recvd packets */
 
 /*
  * Structure used for manipulating linger option.


### PR DESCRIPTION
Implements `SO_TIMESTAMPING`/`SO_TIMESTAMP` socket option to put timestamps onto received UDP packets at the time of arrival into TCP/IP stack.