### PR TITLE
Reset DNS server index on new DNS entries

### DIFF
--- a/src/core/dns.c
+++ b/src/core/dns.c
@@ -1516,6 +1516,7 @@ dns_enqueue(const char *name, size_t hostnamelen, dns_found_callback found,
   entry->state = DNS_STATE_NEW;
   entry->seqno = dns_seqno;
   entry->if_idx = if_idx;
+  entry->server_idx = 0;
   LWIP_DNS_SET_ADDRTYPE(entry->reqaddrtype, dns_addrtype);
   LWIP_DNS_SET_ADDRTYPE(req->reqaddrtype, dns_addrtype);
   req->found = found;


### PR DESCRIPTION
## Problem Description ##
Msom devices can get stuck in a state where they cannot resolve the cloud hostname IP when connectivity moves between interfaces (ie a device has ethernet + wifi, wifi fails but then DNS does not resolve using ethernet DNS servers). 

The problem state is when there are interfaces that are IP configured and have DNS servers available, but those DNS servers are not successfully resolving. This can happen with cellular connections with poor connectivity or can be artificially created with ethernet switches by disconnecting the upstream connection. The device will still have an IP but DNS will not resolve and IP traffic does not send. 

In this situation we are supposed to "fail over" to any other available DNS server but this is not happening. We are stuck on the non functional DNS server. 

## Root Cause ##
The root cause of this problem is that **DNS table entries are not fully zeroed** when they expire. They retain the previous DNS server index from the last time they were resolved. When we try a new DNS resolution, it will reuse the same failing DNS server index and not increment/rollover to other available DNS servers. 

Note: Things are only broken if you are failing *downwards* in the order of ethernet -> cellular -> wifi, since `next_server_index()` will only increment upwards for the next DNS server. If you are failing *upwards* ie wifi -> ethernet, then you will have a chance of finding the next working server associated with the working interface. 

## Solution ##
When we call `dns_enqueue()` for a new DNS request in the `DNS_STATE_NEW` state, we should zero the `server_idx` value to make sure that `dns_check_entry()` will determine the correct DNS server index. 
If no network interface is specified, this should be the first available DNS server in the order Ethernet > Cellular > Wifi.
If there is a specified network interface, this should be the first DNS server associated with that interface.

If we are retrying DNS resolutions, then the request will be re-enqueued with the `DNS_STATE_ASKING` state, and the server index will increment forward via `next_server_index()` as intended. We should try the next available DNS server associated with that interface. 

## Example Logs ##
Here is a device on Ethernet with no upstream internet/DNS communication that has completely failed the cloud connection and is stuck attempting repeated internet tests in the system loop. 

```
0000389660 [system] INFO: Cloud: connecting
0000389661 [app] INFO: Ethernet Ready: 1 WiFi ready: 0 Cellular ready: 0 Cloud conn: 0
0000389673 [app] INFO: Wifi state: 1
0000389666 [system] INFO: Read Server Address = type:1,domain:$id.udp.particle.io
0000389682 [system] WARN: Failed to load session data from persistent storage
0000389692 [system] INFO: Discarding session data
0000389696 [system.cm] TRACE: Using best network: Ethernet
0000389738 [system] TRACE: Resolving 0a10aced202194944a04ada8.v6.udp.particle.io#5684 cache=1 iface=3
0000389744 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS entry 0
0000389752 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS pcb 0

// Here is the DNS request starting with server index 0, then finding the ethernet DNS server at index 6. This request times out
0000389762 [lwip] TRACE: dns_check_entry: i:0 entry state:1 server_idx:0 if_idx:3 tmr:0 retries:3 ttl:0
0000389772 [lwip] TRACE: dns_check_entry: new entry->server_idx: 6 entry->if_idx: 3
0000389780 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000389791 [lwip] TRACE: sending DNS request ID 63574 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6


0000390632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:0 ttl:0
0000390637 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000390646 [lwip] TRACE: sending DNS request ID 63574 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6
0000391632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:1 ttl:0
0000391638 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000391646 [lwip] TRACE: sending DNS request ID 63574 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6
0000392632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:2 retries:2 ttl:0
0000393632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:2 ttl:0
0000393636 [lwip] TRACE: dns_check_entry: "0a10aced202194944a04ada8.v6.udp.particle.io": timeout
0000393645 [system] ERROR: Failed to determine server address: 202
0000393651 [system] TRACE: Address type: 3
0000393654 [system] WARN: Cloud socket connection failed: -230
0000393660 [system.cm] INFO: testConnections full
0000393665 [system.cm] INFO: Full reachability test started: 1
0000393671 [system.cm] TRACE: Last rechability test failed, using interface en2 for DNS queries explicitly
0000393699 [system] TRACE: Resolving 0a10aced202194944a04ada8.v6.udp.particle.io#5684 cache=0 iface=3
0000393703 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS entry 0
0000393712 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS pcb 0
0000393720 [lwip] TRACE: dns_check_entry: i:0 entry state:1 server_idx:0 if_idx:3 tmr:0 retries:3 ttl:0
0000393730 [lwip] TRACE: dns_check_entry: new entry->server_idx: 6 entry->if_idx: 3
0000393737 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000393747 [lwip] TRACE: sending DNS request ID 41601 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6
0000394632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:0 ttl:0
0000394636 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000394646 [lwip] TRACE: sending DNS request ID 41601 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6
0000395632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:1 ttl:0
0000395636 [lwip] TRACE: dns_send: dns_servers[6] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000395646 [lwip] TRACE: sending DNS request ID 41601 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 6
0000396632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:2 retries:2 ttl:0
0000397632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:2 ttl:0
0000397637 [lwip] TRACE: dns_check_entry: "0a10aced202194944a04ada8.v6.udp.particle.io": timeout
0000397646 [system] ERROR: Failed to determine server address: 202
0000397651 [system] WARN: Internet test failed: -170 DNS
0000397656 [system] WARN: Handling cloud error: 2
```

Here is when WIFI comes back up, and the DNS resolution correctly switches to the DNS server associated with wifi (Note the connection manager test changes as well, those were not correctly rotating interfaces/DNS servers)
```
0000417137 [ncp.rltk.client] TRACE: NCP connection state changed: 2
0000417139 [net.rltkncp] TRACE: NCP event 2
0000417142 [net.rltkncp] TRACE: State changed event: 2
0000417148 [net.ifapi] INFO: Netif wl4 link UP, profile=derp
0000417177 [hal] INFO: DNS server list changed
0000417180 [net.ifapi] TRACE: Netif wl4 ipv4 configuration changed
0000417632 [lwip] TRACE: dns_check_entry: i:0 entry state:2 server_idx:6 if_idx:3 tmr:1 retries:2 ttl:0
0000417637 [lwip] TRACE: dns_check_entry: "0a10aced202194944a04ada8.v6.udp.particle.io": timeout
0000417646 [system] ERROR: Failed to determine server address: 202
0000417651 [system] TRACE: Address type: 3
0000417655 [system] WARN: Cloud socket connection failed: -230
0000417661 [system.cm] INFO: testConnections full
0000417665 [system.cm] INFO: Full reachability test started: 1

// Connection manager specifying wifi explicitly
0000417671 [system.cm] TRACE: Last rechability test failed, using interface wl4 for DNS queries explicitly
0000417700 [system] TRACE: Resolving 0a10aced202194944a04ada8.v6.udp.particle.io#5684 cache=0 iface=5
0000417704 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS entry 0
0000417712 [lwip] TRACE: dns_enqueue: "0a10aced202194944a04ada8.v6.udp.particle.io": use DNS pcb 0

// New DNS request starts with index 0
0000417722 [lwip] TRACE: dns_check_entry: i:0 entry state:1 server_idx:0 if_idx:5 tmr:0 retries:3 ttl:0
// Wifi DNS server selected for request
0000417731 [lwip] TRACE: dns_check_entry: new entry->server_idx: 10 entry->if_idx: 5
0000417739 [lwip] TRACE: dns_send: dns_servers[10] "0a10aced202194944a04ada8.v6.udp.particle.io": request
0000417747 [lwip] TRACE: sending DNS request ID 43558 for name "0a10aced202194944a04ada8.v6.udp.particle.io" to server 10
0000417798 [lwip] TRACE: dns_recv: "0a10aced202194944a04ada8.v6.udp.particle.io": response =

// Resolution succeeds
0000417802 [lwip] TRACE: 18.213.90.196
0000417806 [lwip] TRACE:
```
