### PR TITLE
Tethering fixes

### DIFF
--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -983,27 +983,30 @@ lwip_netconn_do_close_internal(struct netconn *conn  WRITE_DELAYED_PARAM)
 #if LWIP_SO_LINGER
     /* check linger possibilites before calling tcp_close */
     err = ERR_OK;
-    /* linger enabled/required at all? (i.e. is there untransmitted data left?) */
-    if ((conn->linger >= 0) && (conn->pcb.tcp->unsent || conn->pcb.tcp->unacked)) {
-      if ((conn->linger == 0)) {
-        /* data left but linger prevents waiting */
+    /* SO_LINGER with l_linger == 0 means "on close, discard any data and send a
+     * RST" (POSIX). Do so unconditionally - not only when data is still pending -
+     * so the PCB is freed immediately instead of lingering in FIN_WAIT/TIME_WAIT.
+     * This lets a RAM-constrained device reclaim scarce TCP PCBs right away when
+     * many short-lived connections churn (e.g. iperf control sockets). */
+    if (conn->linger == 0) {
+      tcp_abort(tpcb);
+      tpcb = NULL;
+    }
+    /* linger > 0: only relevant if there is untransmitted data left */
+    else if ((conn->linger > 0) && (conn->pcb.tcp->unsent || conn->pcb.tcp->unacked)) {
+      /* data left and linger says we should wait */
+      if (netconn_is_nonblocking(conn)) {
+        /* data left on a nonblocking netconn -> cannot linger */
+        err = ERR_WOULDBLOCK;
+      } else if ((s32_t)(sys_now() - conn->current_msg->msg.sd.time_started) >=
+                 (conn->linger * 1000)) {
+        /* data left but linger timeout has expired (this happens on further
+           calls to this function through poll_tcp */
         tcp_abort(tpcb);
         tpcb = NULL;
-      } else if (conn->linger > 0) {
-        /* data left and linger says we should wait */
-        if (netconn_is_nonblocking(conn)) {
-          /* data left on a nonblocking netconn -> cannot linger */
-          err = ERR_WOULDBLOCK;
-        } else if ((s32_t)(sys_now() - conn->current_msg->msg.sd.time_started) >=
-                   (conn->linger * 1000)) {
-          /* data left but linger timeout has expired (this happens on further
-             calls to this function through poll_tcp */
-          tcp_abort(tpcb);
-          tpcb = NULL;
-        } else {
-          /* data left -> need to wait for ACK after successful close */
-          linger_wait_required = 1;
-        }
+      } else {
+        /* data left -> need to wait for ACK after successful close */
+        linger_wait_required = 1;
       }
     }
     if ((err == ERR_OK) && (tpcb != NULL))

--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -983,12 +983,7 @@ lwip_netconn_do_close_internal(struct netconn *conn  WRITE_DELAYED_PARAM)
 #if LWIP_SO_LINGER
     /* check linger possibilites before calling tcp_close */
     err = ERR_OK;
-    /* SO_LINGER with l_linger == 0 means "on close, discard any data and send a
-     * RST" (POSIX). Do so unconditionally - not only when data is still pending -
-     * so the PCB is freed immediately instead of lingering in FIN_WAIT/TIME_WAIT.
-     * This lets a RAM-constrained device reclaim scarce TCP PCBs right away when
-     * many short-lived connections churn (e.g. iperf control sockets). */
-    if (conn->linger == 0) {
+    if (conn->linger == 0 && tpcb->state != LISTEN) {
       tcp_abort(tpcb);
       tpcb = NULL;
     }

--- a/src/api/err.c
+++ b/src/api/err.c
@@ -58,7 +58,7 @@ static const int err_to_errno_table[] = {
   EALREADY,      /* ERR_ALREADY    -9      Already connecting.      */
   EISCONN,       /* ERR_ISCONN     -10     Conn already established.*/
   ENOTCONN,      /* ERR_CONN       -11     Not connected.           */
-  -1,            /* ERR_IF         -12     Low-level netif error    */
+  EIO,           /* ERR_IF         -12     Low-level netif error    */
   ECONNABORTED,  /* ERR_ABRT       -13     Connection aborted.      */
   ECONNRESET,    /* ERR_RST        -14     Connection reset.        */
   ENOTCONN,      /* ERR_CLSD       -15     Connection closed.       */

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -604,12 +604,12 @@ tcp_input_delayed_close(struct tcp_pcb *pcb)
   if (recv_flags & TF_CLOSED) {
     /* The connection has been closed and we will deallocate the
         PCB. */
-    if (!(pcb->flags & TF_RXCLOSED)) {
-      /* Connection closed although the application has only shut down the
-          tx side: call the PCB's err callback and indicate the closure to
-          ensure the application doesn't continue using the PCB. */
-      TCP_EVENT_ERR(pcb->state, pcb->errf, pcb->callback_arg, ERR_CLSD);
-    }
+    /* Always call the err callback to notify the application (netconn)
+        that the PCB has been freed. Without this, the netconn layer
+        keeps a reference to the freed PCB, and a subsequent close()
+        call frees it again, causing a TCP_PCB double-free.
+        See: https://savannah.nongnu.org/bugs/?62141 */
+    TCP_EVENT_ERR(pcb->state, pcb->errf, pcb->callback_arg, ERR_CLSD);
     tcp_pcb_remove(&tcp_active_pcbs, pcb);
     tcp_free(pcb);
     return 1;

--- a/src/include/netif/ppp/ppp.h
+++ b/src/include/netif/ppp/ppp.h
@@ -384,6 +384,10 @@ struct ppp_pcb_s {
   u16_t peer_mru;                /* currently negotiated peer MRU */
   u8_t lcp_echos_pending;        /* Number of outstanding echo msgs */
   u8_t lcp_echo_number;          /* ID number of next echo frame */
+#if PPP_LCP_ADAPTIVE
+  u32_t link_pkts_in;            /* Total received PPP frames (for adaptive echo) */
+  u32_t link_pkts_in_last;       /* pkts_in as of the last adaptive echo check */
+#endif /* PPP_LCP_ADAPTIVE */
 
   u8_t num_np_open;              /* Number of network protocols which we have opened. */
   u8_t num_np_up;                /* Number of network protocols which have come up. */

--- a/src/netif/ppp/lcp.c
+++ b/src/netif/ppp/lcp.c
@@ -2731,15 +2731,8 @@ static void LcpSendEchoRequest(fsm *f) {
      * no traffic was received since the last one.
      */
     if (pcb->settings.lcp_echo_adaptive) {
-	static unsigned int last_pkts_in = 0;
-
-#if PPP_STATS_SUPPORT
-	update_link_stats(f->unit);
-	link_stats_valid = 0;
-#endif /* PPP_STATS_SUPPORT */
-
-	if (link_stats.pkts_in != last_pkts_in) {
-	    last_pkts_in = link_stats.pkts_in;
+	if (pcb->link_pkts_in != pcb->link_pkts_in_last) {
+	    pcb->link_pkts_in_last = pcb->link_pkts_in;
 	    return;
 	}
     }

--- a/src/netif/ppp/ppp.c
+++ b/src/netif/ppp/ppp.c
@@ -779,6 +779,11 @@ void ppp_input(ppp_pcb *pcb, struct pbuf *pb) {
 
   magic_randomize();
 
+#if PPP_LCP_ADAPTIVE
+  /* Track all received PPP frames for adaptive LCP echo */
+  pcb->link_pkts_in++;
+#endif /* PPP_LCP_ADAPTIVE */
+
   if (pb->len < 2) {
     PPPDEBUG(LOG_ERR, ("ppp_input[%d]: packet too short\n", pcb->netif->num));
     goto drop;


### PR DESCRIPTION
- [ppp] lcp: per-pcb RX frame counter for adaptive echo instead of a global one (non instanced)
- [tcp] fix tcp_pcb double-free in tcp_input_delayed_close()  - backport from https://savannah.nongnu.org/bugs/?62141
- [api] err: map ERR_IF to EIO instead of -1 and propagation of ERR_IF as errno
- [api] netconn: abort on close with SO_LINGER timeout 0 regardless of pending data - keeps RAM use behaved on Gen 3 platforms (? should probably enable this by default too on those?)
